### PR TITLE
⚡ set nrf52840 uart to 1M

### DIFF
--- a/samples/direct-draw/CMakeLists.txt
+++ b/samples/direct-draw/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION 3.20.0)
-find_package(Zephyr REQUIRED)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(terminal-display-direct-draw-tests)
 target_sources(app PRIVATE main.c utils.c)

--- a/samples/lvgl/CMakeLists.txt
+++ b/samples/lvgl/CMakeLists.txt
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-find_package(Zephyr REQUIRED)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(terminal-display-tests)
-target_sources(app PRIVATE 
-    main.c 
+target_sources(app PRIVATE
+    main.c
     particle.c
 )

--- a/samples/lvgl/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/lvgl/boards/nrf52840dk_nrf52840.overlay
@@ -19,3 +19,7 @@
     };
 };
 
+/* Default UART baud rate is 115200. Set it to the maximum, 1M */
+&uart0 {
+    current-speed = <1000000>;
+};


### PR DESCRIPTION
Also correct the `find_package()` cmake function- it needs to pull `ZEPHYR_BASE` environment variable to build in a normal Zephyr workspace, i.e.:

```bash
❯ mkdir zephyr-terminal-display
❯ cd zephyr-terminal-display
❯ west init -m git@github.com:xv-engineering/zephyr-terminal-display.git
❯ west update --narrow -o=--depth=1
❯ west build --pristine always --board nrf52840dk/nrf52840 terminal-display/samples/lvgl
```

All of Zephyr in-tree samples use this same idiom.